### PR TITLE
chore: add Dependabot config for Gradle and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gradle"
+    directory: "/convention"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: ./gradlew build
 
       - name: Publish
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(main): release')
+        if: "github.ref == 'refs/heads/main' && github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(main): release')"
         run: ./gradlew publish
         env:
           GITHUB_ACTOR: ${{ github.actor }}


### PR DESCRIPTION
Enables weekly Dependabot updates for:
- Gradle dependencies (root project)
- Gradle dependencies (convention included build)
- GitHub Actions